### PR TITLE
CSU-318: Fixing requested on data-table for staff

### DIFF
--- a/src/components/02-components/data-table/data-table.data.tsx
+++ b/src/components/02-components/data-table/data-table.data.tsx
@@ -196,6 +196,7 @@ export const staffTableColumns = [
             flexShrink: 0,
             fontWeight: 700,
             border: '1px solid',
+            whiteSpace: 'nowrap',
           }}
         >
           Manage Departments

--- a/src/components/04-pages/generic/data-table-page.tsx
+++ b/src/components/04-pages/generic/data-table-page.tsx
@@ -78,6 +78,7 @@ export default function DataTablePage({
         columns={tableData.columns}
         toolbar={tableData.toolbar}
         filters={tableData.filters}
+        hideCols={tableData.hideCols}
       />
     </>
   );


### PR DESCRIPTION
## Purpose:
Added `nowrap` CSS property to button and fixed the `hideCols` props in data-table

### Ticket(s)
[CSU-318](https://fourkitchens.clickup.com/t/36718269/CSU-318)

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] load `/organization/staff` without any deparment.

### Notes:
none
