### PR TITLE
Feat: added skip content button to main layout and fixing labels.

### DIFF
--- a/src/components/02-components/address-field/address-field.tsx
+++ b/src/components/02-components/address-field/address-field.tsx
@@ -315,10 +315,10 @@ export default function AddressField({
   const idPrefix = typeof id !== 'undefined' ? `${id}-` : '';
 
   return (
-    <Box sx={containerStyles} {...props}>
-      <Typography variant="h3" mb={4}>
+    <Box component="fieldset" sx={containerStyles} {...props}>
+      <legend>
         {address?.label ?? 'Address'}
-      </Typography>
+      </legend>
       <FormControl fullWidth>
         <InputLabel id={`${idPrefix}address-country-label`}>Country</InputLabel>
         <Select

--- a/src/components/02-components/main-content/main-content.tsx
+++ b/src/components/02-components/main-content/main-content.tsx
@@ -5,12 +5,16 @@ type MainContentProps = {
   children: ReactNode;
   sidebarOpen: boolean;
   sidebarWidth: number;
+  id: string;
+  tabIndex?: number;
 };
 
 export default function MainContent({
   children,
   sidebarOpen,
   sidebarWidth,
+  id,
+  tabIndex
 }: MainContentProps) {
   const theme = useTheme();
 
@@ -39,7 +43,7 @@ export default function MainContent({
   };
 
   return (
-    <Box component="main" sx={mainStyles}>
+    <Box component="main" sx={mainStyles} id={id} tabIndex={tabIndex}>
       {children}
     </Box>
   );

--- a/src/components/02-components/tabs/tabs.tsx
+++ b/src/components/02-components/tabs/tabs.tsx
@@ -80,7 +80,7 @@ const Tabs = forwardRef<RefHandler, TabsProps>(function Tabs(
   Children.forEach(children, (child, index) => {
     if (child && child.props.title) {
       renderedTabs.push(
-        <Tab key={index} label={child.props.title} {...a11yProps(id, index)} />,
+        <Tab key={index} label={child.props.title} tabIndex={0} {...a11yProps(id, index)} />,
       );
       renderedTabPanels.push(
         <TabPanel

--- a/src/components/03-layouts/page-layout/page-layout.tsx
+++ b/src/components/03-layouts/page-layout/page-layout.tsx
@@ -1,4 +1,4 @@
-import { Box, useMediaQuery, useTheme } from '@mui/material';
+import { Box, useMediaQuery, Button, useTheme } from '@mui/material';
 import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import SidebarToggle from '../../01-elements/sidebar-toggle/sidebar-toggle';
 import BrandingBar, {
@@ -29,6 +29,7 @@ export default function PageLayout({
   const [sidebarOpen, setSidebarOpen] = useState<boolean | undefined>(
     undefined,
   );
+  const [showSkipButton, setShowSkipButton] = useState(false); // Track whether to show skip button
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
@@ -39,6 +40,28 @@ export default function PageLayout({
 
   const sidebarWidth = 23;
 
+  const handleSkipContent = () => {
+    // Focus on the main content when the skip content link is clicked
+    document.getElementById("main-content")?.focus();
+    // Hide the skip content button after it's clicked
+    setShowSkipButton(false);
+  };
+
+  const handleTabKeyPress = (event: { key: string; }) => {
+    // Show skip button when Tab key is pressed
+    if (event.key === 'Tab') {
+      setShowSkipButton(true);
+    }
+  };
+
+  useEffect(() => {
+    // Add event listener to detect Tab key press
+    document.addEventListener('keydown', handleTabKeyPress);
+    return () => {
+      document.removeEventListener('keydown', handleTabKeyPress);
+    };
+  }, []);
+
   return (
     <Box>
       <Box
@@ -48,8 +71,15 @@ export default function PageLayout({
           right: 0,
           top: 0,
           zIndex: (theme) => theme.zIndex.drawer + 1,
+          backgroundColor: 'white',
         }}
       >
+        {/* Skip content button/link */}
+        {showSkipButton && (
+          <Button variant="contained" sx={{ margin: theme.spacing(1) }} onClick={handleSkipContent}>
+            Skip to main content
+          </Button>
+        )}
         <BrandingBar {...brandingBarLinks} />
         <TopBar>
           {brand}
@@ -63,9 +93,12 @@ export default function PageLayout({
         >
           <SidebarMenu {...sidebarLinks} />
         </Sidebar>
+        {/* Main content with tabIndex to make it focusable */}
         <MainContent
           sidebarOpen={sidebarOpen as boolean}
           sidebarWidth={sidebarWidth}
+          id="main-content"
+          tabIndex={-1}
         >
           {children}
         </MainContent>


### PR DESCRIPTION
## Purpose:
Fixing this item from the accessibility check list:
1. WAVE detected a skipped header in Address (Header Level 3, no Header Level 2). 
2. No "Skip to content" button/link.

### Ticket(s)
none

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] Run storybook and load the components `page layout` and `add-offering`

### Notes:
none
