### PR TITLE
feat(csu-207): Added duration step form

### DIFF
--- a/src/components/02-components/student-experience-form-step2/student-experience-form-step2.stories.tsx
+++ b/src/components/02-components/student-experience-form-step2/student-experience-form-step2.stories.tsx
@@ -10,7 +10,14 @@ const meta: Meta<typeof StudentExperienceFormStep2> = {
 
 export default meta;
 
-const stepsNames = ['Opportunity','Program + Course','Health and Safety Information','Approval','Staff','Duration', 'Summary'];
+const stepsNames = [
+  'Opportunity',
+  'Program + Course',
+  'Health and Safety Information',
+  'Approval',
+  'Duration',
+  'Summary',
+];
 const stepsBar = (
   <StepsBar
     steps={stepsNames}

--- a/src/components/02-components/student-experience-form-step3/student-experience-form-step3.stories.tsx
+++ b/src/components/02-components/student-experience-form-step3/student-experience-form-step3.stories.tsx
@@ -15,7 +15,6 @@ const stepsNames = [
   'Program + Course',
   'Health and Safety Information',
   'Approval',
-  'Staff',
   'Duration',
   'Summary',
 ];

--- a/src/components/02-components/student-experience-form-step4/student-experience-form-step4.stories.tsx
+++ b/src/components/02-components/student-experience-form-step4/student-experience-form-step4.stories.tsx
@@ -15,7 +15,6 @@ const stepsNames = [
   'Program + Course',
   'Health and Safety Information',
   'Approval',
-  'Staff',
   'Duration',
   'Summary',
 ];

--- a/src/components/02-components/student-experience-form-step5/student-experience-form-step5.stories.tsx
+++ b/src/components/02-components/student-experience-form-step5/student-experience-form-step5.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import StudentExperienceFormStep5 from './student-experience-form-step5';
+import StepsBar from '../steps-bar/steps-bar';
+import React from 'react';
+
+const meta: Meta<typeof StudentExperienceFormStep5> = {
+  title: 'Components/Student Experience Form Step 5',
+  component: StudentExperienceFormStep5,
+};
+
+export default meta;
+
+const stepsNames = [
+  'Opportunity',
+  'Program + Course',
+  'Health and Safety Information',
+  'Approval',
+  'Duration',
+  'Summary',
+];
+
+const stepsBar = <StepsBar steps={stepsNames} step={'4'} />;
+
+export const AddStudentExperienceFormStep5: StoryObj<typeof StudentExperienceFormStep5> = {
+  args: {
+    opportunityId: '1',
+    programId: '2',
+    opportunityCourseId: '2',
+    healthSafetySelected: '1',
+    stepsBar: stepsBar,
+    term: 'Fall 2021',
+    estimatedHours: 10,
+  },
+};

--- a/src/components/02-components/student-experience-form-step5/student-experience-form-step5.tsx
+++ b/src/components/02-components/student-experience-form-step5/student-experience-form-step5.tsx
@@ -1,0 +1,150 @@
+import {
+  Box,
+  Button,
+  Stack,
+  Paper,
+  Typography,
+  useTheme,
+  OutlinedInput,
+  InputAdornment,
+} from '@mui/material';
+import { ElementType, ReactNode } from 'react';
+
+export type StudentExperienceFormStep5Props = {
+  opportunityId: string;
+  programId: string;
+  opportunityCourseId: string;
+  healthSafetySelected: string;
+  stepsBar: ReactNode;
+  FormElement: ElementType;
+  term: string;
+  estimatedHours: number;
+};
+
+export default function StudentExperienceFormStep5({
+  opportunityId,
+  programId,
+  opportunityCourseId,
+  healthSafetySelected,
+  stepsBar,
+  FormElement,
+  term,
+  estimatedHours,
+}: StudentExperienceFormStep5Props) {
+  const theme = useTheme();
+
+  // Styles.
+  const contentContainer = {
+    padding: theme.spacing(4),
+    marginBottom: theme.spacing(4),
+  };
+
+  const label = {
+    fontWeight: '700',
+    color: theme.palette.primary.main,
+  };
+
+  // Form.
+  const formInner = (
+    <>
+      <Paper sx={contentContainer}>
+        <Typography
+          variant="h2"
+          color="primary.main"
+          sx={{ mb: theme.spacing(2) }}
+        >
+          Duration
+        </Typography>
+        <Box>
+          <Stack direction="row" spacing={1} sx={{ mb: theme.spacing(2) }}>
+            <Typography variant="body1" sx={label}>
+              Term:
+            </Typography>
+            <Typography variant="body1">{term}</Typography>
+          </Stack>
+          <Stack direction="column" spacing={0} sx={{ mb: theme.spacing(4) }}>
+            <Typography variant="body1" sx={label}>
+              Time Commitment
+            </Typography>
+            <Typography variant="body1">
+              This location currently has no minimum hours requirement.
+            </Typography>
+            <Typography variant="body1">
+              Please estimate the minimum number of hours you will serve at this
+              site.
+            </Typography>
+          </Stack>
+        </Box>
+        <OutlinedInput
+          type="number"
+          id="estimatedHours"
+          name="estimatedHours"
+          defaultValue={estimatedHours || 0}
+          onChange={(e) => {
+            e.preventDefault();
+          }}
+          endAdornment={<InputAdornment position="end">Hours</InputAdornment>}
+          inputProps={{ min: 0 }}
+        />
+      </Paper>
+      <input type="hidden" name="opportunityId" value={opportunityId} />
+      <input
+        type="hidden"
+        name="opportunityCourse"
+        value={opportunityCourseId}
+      />
+      <input type="hidden" name="programId" value={programId} />
+      <input
+        type="hidden"
+        name="healthSafetyInformation"
+        value={healthSafetySelected}
+      />
+      <input type="hidden" name="estimatedHours" value={estimatedHours} />
+      <Button
+        type="button"
+        href="/create-experience"
+        variant="outlined"
+        sx={{ mr: 1, float: 'left' }}
+      >
+        Cancel
+      </Button>
+      <Button type="submit" variant="contained" sx={{ mr: 1, float: 'right' }}>
+        Save and Submit
+      </Button>
+      <Button
+        type="button"
+        href={`/create-experience/health-safety?opportunity=${opportunityId}&program=${programId}&course=${opportunityCourseId}&healthSafety=${healthSafetySelected}`}
+        variant="outlined"
+        sx={{ mr: 1, float: 'right' }}
+      >
+        Back
+      </Button>
+    </>
+  );
+
+  const form = FormElement ? (
+    <FormElement method="post">{formInner}</FormElement>
+  ) : (
+    <form>{formInner}</form>
+  );
+
+  return (
+    <>
+      <Paper sx={contentContainer}>
+        <Typography
+          variant="h1"
+          color="primary.main"
+          sx={{ mb: theme.spacing(2) }}
+        >
+          Create your Experience
+        </Typography>
+        <Typography variant="body1">
+          This simple process will guide you through the steps to sign up for
+          your selected experiential learning opportunity.
+        </Typography>
+      </Paper>
+      {stepsBar}
+      {form}
+    </>
+  );
+}

--- a/src/components/02-components/student-experience-form/student-experience-form.stories.tsx
+++ b/src/components/02-components/student-experience-form/student-experience-form.stories.tsx
@@ -13,7 +13,14 @@ const meta: Meta<typeof StudentExperienceForm> = {
 
 export default meta;
 
-const stepsNames = ['Opportunity','Program + Course','Health and Safety Information','Approval','Staff','Duration', 'Summary'];
+const stepsNames = [
+  'Opportunity',
+  'Program + Course',
+  'Health and Safety Information',
+  'Approval',
+  'Duration',
+  'Summary',
+];
 const stepsBar = (
   <StepsBar
     steps={stepsNames}

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,10 @@ export {
   type StudentExperienceFormStep4Props,
 } from './components/02-components/student-experience-form-step4/student-experience-form-step4'
 export {
+  default as StudentExperienceFormStep5,
+  type StudentExperienceFormStep5Props,
+} from './components/02-components/student-experience-form-step5/student-experience-form-step5'
+export {
   default as StaffArchiveMember,
   type StaffArchiveMemberProps,
 } from './components/02-components/staff-archive-member/staff-archive-member';


### PR DESCRIPTION
## Purpose:
- Updated the `stepBar` for all previous steps, deleting the step 'Staff'.
- Added step 'Duration' as a component ready to be used on the student's app.

### Ticket(s)
[CSU-207](https://fourkitchens.clickup.com/t/36718269/CSU-207)

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] Run storybook and load `/?path=/story/components-student-experience-form-step-5--add-student-experience-form-step-5` compare to Figma to ensure look and feel.

### Notes:
none
