### PR TITLE
CSU-532: Add mobile and desktop responsive changes

### DIFF
--- a/src/components/02-components/card-experiences-list/card-experiences-list.tsx
+++ b/src/components/02-components/card-experiences-list/card-experiences-list.tsx
@@ -1,4 +1,4 @@
-import { Box, useTheme } from '@mui/material';
+import { Box, useTheme, useMediaQuery } from '@mui/material';
 import { type ReactNode } from 'react';
 
 export type CardExperiencesListProps = {
@@ -10,18 +10,21 @@ export default function CardExperiencesList({
 }: CardExperiencesListProps) {
   const theme = useTheme();
 
+  const isMobile = useMediaQuery(theme.breakpoints.down('xl'));
+
   // Styles.
   const containerStyles = {
     pt: theme.spacing(5),
     px: theme.spacing(0.5),
     pb: theme.spacing(0.5),
-    overflowX: 'auto',
+    overflow: 'hidden',
     width: '100%',
   };
 
   const listStyles = {
-    display: 'flex',
+    display: 'grid',
     gap: theme.spacing(2),
+    gridTemplateColumns: isMobile ? 'repeat(1, 1fr)' : 'repeat(2, 1fr)',
   };
 
   return (


### PR DESCRIPTION
## Purpose:
- Add mobile and desktop change to vertical positioning

### Ticket(s)
[CSU-532]  Make experience listing pages scroll vertically instead of horizontally

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [x] pull changes
- [x] go to /?path=/story/components-card-experiences-list--default
- [x] check vertical scroll instead of horizontal and you can add more cards in card-experiences-list.stories.tsx to test

### Notes:
-
