### PR TITLE
CSU-535: Add styling change of single component of the opportunities card

### DIFF
--- a/src/components/00-tokens/icon/material/material-icons.stories.tsx
+++ b/src/components/00-tokens/icon/material/material-icons.stories.tsx
@@ -26,7 +26,8 @@ const MaterialIconsData = {
     'Schedule',
     'SwitchAccount',
     'PeopleAlt',
-    'ErrorOutline'
+    'ErrorOutline',
+    'CheckCircleOutline',
   ],
 }
 

--- a/src/components/02-components/opportunity-card/opportunity-card.stories.tsx
+++ b/src/components/02-components/opportunity-card/opportunity-card.stories.tsx
@@ -29,6 +29,7 @@ export const Default: StoryObj<typeof OpportunityCard> = {
     termPeriod: 'Fall 2023',
     program: 'Service Learning',
     description,
+    approvalState: false,
   },
 };
 

--- a/src/components/02-components/opportunity-card/opportunity-card.tsx
+++ b/src/components/02-components/opportunity-card/opportunity-card.tsx
@@ -9,6 +9,8 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 import Link from '../../01-elements/link/link';
 
 export type OpportunityCardProps = {
@@ -24,6 +26,7 @@ export type OpportunityCardProps = {
   description?: string;
   cardSelected?: boolean;
   requirements?: string;
+  approvalState: boolean;
 };
 
 export default function OpportunityCard({
@@ -39,10 +42,49 @@ export default function OpportunityCard({
   description,
   cardSelected,
   requirements,
+  approvalState,
 }: OpportunityCardProps) {
   const theme = useTheme();
 
+  const approvalStatus = approvalState ? 'reviewing' : 'approved';
+
+  const approvalStates: Record<
+    string,
+    {
+      label: string;
+      backgroundColor: string;
+    }
+  > = {
+    approved: {
+      label: 'approved',
+      backgroundColor: 'success.dark',
+    },
+    reviewing: {
+      label: 'reviewing',
+      backgroundColor: 'warning.main',
+    },
+  };
+
   // Styles.
+  const statusStyles = {
+    borderRadius: theme.spacing(0.5),
+    display: 'inline-flex',
+    textTransform: 'uppercase',
+    fontSize: '0.875rem',
+    fontWeight: '700',
+    px: theme.spacing(1),
+    py: theme.spacing(0.5),
+    mt: theme.spacing(1),
+    [theme.breakpoints.up('sm')]: {
+      mt: 0,
+    },
+
+    'svg': {
+      maxWidth: '20px',
+      height: 'auto',
+    }
+  };
+
   const accordionSummaryStyles = {
     '& .MuiAccordionSummary-expandIconWrapper': {
       mt: theme.spacing(1.5),
@@ -116,6 +158,16 @@ export default function OpportunityCard({
               {termPeriod && (
                 <Typography sx={subtitleStyles}>{termPeriod}</Typography>
               )}
+              <Typography
+                sx={{
+                  ...statusStyles,
+                  backgroundColor: approvalStates[approvalStatus].backgroundColor,
+                }}
+                component="span"
+              >
+                {}
+                {approvalStates[approvalStatus].label == 'reviewing' ? <ErrorOutlineIcon /> : <CheckCircleOutline />}
+              </Typography>
             </Box>
           </Box>
         </AccordionSummary>

--- a/src/components/02-components/opportunity-list/opportunity-list.stories.tsx
+++ b/src/components/02-components/opportunity-list/opportunity-list.stories.tsx
@@ -63,7 +63,7 @@ export const Default: StoryObj<typeof OpportunityList> = {
         url: '#',
       },
     ],
-    url: 'http://localhost:6006/',
+    url: '#http://localhost:6006/',
     children: opportunities,
     listView: true,
     totalItems: 30,


### PR DESCRIPTION
## Purpose:
- Add styling change of single component of the opportunities card adding a icon for information

### Ticket(s)
[CSU-XX](https://fourkitchens.clickup.com/t/36718269/CSU-XX)

### Pull Request Deployment:
- Pull

### Functional Testing:
- [ ] Go to /?path=/story/components-opportunity-list--default 
- [ ] if there are icon on the right side everything is correct

### Notes:
N/A
