### PR TITLE
CSU-531: Added approve experiences page.

### DIFF
--- a/src/components/02-components/data-table/data-table.data.tsx
+++ b/src/components/02-components/data-table/data-table.data.tsx
@@ -677,7 +677,7 @@ export const ApproveExperienceTableColumns = [
   { field: 'opportunityProgram', headerName: 'Opportunity Program', width: 150 },
   {
     field: 'col5',
-    headerName: 'Approve',
+    headerName: '',
     width: 120,
     type: 'actions',
     disableExport: true,
@@ -703,7 +703,7 @@ export const ApproveExperienceTableColumns = [
   },
   {
     field: 'col6',
-    headerName: 'Deny',
+    headerName: '',
     width: 120,
     type: 'actions',
     disableExport: true,

--- a/src/components/02-components/data-table/data-table.data.tsx
+++ b/src/components/02-components/data-table/data-table.data.tsx
@@ -667,3 +667,85 @@ export const membershipsRequestsTableRows = [
     email: 'csmit@test.com',
   }
 ];
+
+export const ApproveExperienceTableColumns = [
+  { field: 'experienceId', headerName: 'ID', width: 80 },
+  { field: 'offeringName', headerName: 'Offering Name', width: 120 },
+  { field: 'offeringDepartment', headerName: 'Offering Department', width: 150 },
+  { field: 'studentName', headerName: 'Student Name', width: 150 },
+  { field: 'university', headerName: 'University', width: 150 },
+  { field: 'opportunityProgram', headerName: 'Opportunity Program', width: 150 },
+  {
+    field: 'col5',
+    headerName: 'Approve',
+    width: 120,
+    type: 'actions',
+    disableExport: true,
+    renderCell: (params: GridRenderCellParams) => (
+      <strong>
+        <Button
+          component={Link}
+          href={'#/organization/experience/approve/' + params.row.id}
+          disabled={false}
+          sx={{
+            flexShrink: 0,
+            fontWeight: 700,
+            border: '1px solid',
+            whiteSpace: 'nowrap',
+            margin: '4px 0',
+            color: 'green',
+          }}
+        >
+          Approve
+        </Button>
+      </strong>
+    ),
+  },
+  {
+    field: 'col6',
+    headerName: 'Deny',
+    width: 120,
+    type: 'actions',
+    disableExport: true,
+    renderCell: (params: GridRenderCellParams) => (
+      <strong>
+        <Button
+          component={Link}
+          href={'#/organization/experience/deny/' + params.row.id}
+          disabled={false}
+          sx={{
+            flexShrink: 0,
+            fontWeight: 700,
+            border: '1px solid ',
+            whiteSpace: 'nowrap',
+            margin: '4px 0',
+            color: 'red',
+          }}
+        >
+          Deny
+        </Button>
+      </strong>
+    ),
+  },
+];
+
+export const ApproveExperienceTableRows = [
+  {
+    id: 1,
+    experienceId: '1',
+    offeringName: 'Offering 1',
+    offeringDepartment: 'Department 1',
+    studentName: 'Emily Parker',
+    university: 'CSU',
+    opportunityProgram: 'Blood Drive Admin Assistant',
+  },
+  {
+    id: 2,
+    experienceId: '2',
+    offeringName: 'Offering 2',
+    offeringDepartment: 'Department 2',
+    studentName: 'Carlos Smith',
+    university: 'Channel Islands',
+    opportunityProgram: 'Prison Social Worker',
+  }
+];

--- a/src/components/02-components/data-table/data-table.stories.tsx
+++ b/src/components/02-components/data-table/data-table.stories.tsx
@@ -20,6 +20,8 @@ import {
   reportStudentsTableRows,
   membershipsRequestsTableColumns,
   membershipsRequestsTableRows,
+  ApproveExperienceTableColumns,
+  ApproveExperienceTableRows,
 } from './data-table.data';
 
 const meta: Meta<typeof DataTable> = {
@@ -95,3 +97,11 @@ export const MembershipsRequested: StoryObj<typeof DataTable> = {
     toolbar: () => <GridToolbar title="Memberships Requests" />,
   },
 };
+
+export const ExperiencesWaitingApproval: StoryObj<typeof DataTable> = {
+  args: {
+    rows: ApproveExperienceTableRows,
+    columns: ApproveExperienceTableColumns,
+    toolbar: () => <GridToolbar title="Approve Experience(s)" />,
+  },
+}

--- a/src/components/02-components/tabs/tabs.stories.tsx
+++ b/src/components/02-components/tabs/tabs.stories.tsx
@@ -8,13 +8,13 @@ const meta: Meta<typeof Tabs> = {
   component: Tabs,
   render: () => (
     <Tabs id="custom-tabs" name="Custom Tabs">
-      <Box title="Tab 1">
+      <Box aria-label="Tab 1">
         <h1>Tab 1</h1>
       </Box>
-      <Box title="Tab 2">
+      <Box aria-label="Tab 2">
         <h1>Tab 2</h1>
       </Box>
-      <Box title="Tab 3">
+      <Box aria-label="Tab 3">
         <h1>Tab 2</h1>
       </Box>
     </Tabs>

--- a/src/components/04-pages/approve-experience/approve-experience.stories.tsx
+++ b/src/components/04-pages/approve-experience/approve-experience.stories.tsx
@@ -1,0 +1,50 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import React from 'react';
+import GridToolbar from '../../02-components/data-table/data-table-toolbar.generic';
+import {
+  ApproveExperienceTableColumns,
+  ApproveExperienceTableRows,
+} from '../../02-components/data-table/data-table.data';
+import PageLayout, {
+  type PageLayoutProps,
+} from '../../03-layouts/page-layout/page-layout';
+import { Default as PageLayoutStories } from '../../03-layouts/page-layout/page-layout.stories';
+import ApproveExperiencePage, { type ApproveExperiencePageProps } from './approve-experience';
+
+const meta: Meta<typeof PageLayout> = {
+  title: 'Pages/Experiences/Approve Experience',
+  component: PageLayout,
+};
+
+export default meta;
+
+const staffArgs: ApproveExperiencePageProps = {
+  breadcrumb: [
+    {
+      title: 'Organization',
+      url: '#/organization',
+    },
+    {
+      title: 'Experiences',
+      url: '#/organization/experiences',
+    },
+    {
+      title: 'Pending',
+      url: '#/organization/experiences/pending',
+    },
+  ],
+  title: 'Manage Pending Experiences',
+  tableData: {
+    rows: ApproveExperienceTableRows,
+    columns: ApproveExperienceTableColumns,
+    toolbar: () => <GridToolbar title="Pending experiences" />,
+  }
+};
+
+export const ApproveExperience: StoryObj<typeof PageLayout> = {
+  render: () => (
+    <PageLayout {...(PageLayoutStories.args as PageLayoutProps)}>
+      <ApproveExperiencePage {...(staffArgs as ApproveExperiencePageProps)} />
+    </PageLayout>
+  ),
+};

--- a/src/components/04-pages/approve-experience/approve-experience.tsx
+++ b/src/components/04-pages/approve-experience/approve-experience.tsx
@@ -1,0 +1,51 @@
+import {
+  Paper,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import Breadcrumbs from '../../01-elements/breadcrumbs/breadcrumbs';
+import DataTable, {
+  DataTableProps,
+} from '../../02-components/data-table/data-table';
+
+export type ApproveExperiencePageProps = {
+  breadcrumb: {
+    title: string;
+    url: string;
+  }[];
+  title: string;
+  tableData: DataTableProps;
+  membershipRequestedTableData?: DataTableProps;
+  addUrl?: string;
+  addTitle?: string;
+  id?: string;
+};
+
+export default function ApproveExperiencePage({
+  breadcrumb,
+  title,
+  tableData,
+}: ApproveExperiencePageProps) {
+  const theme = useTheme();
+
+  const titleStyles = {
+    color: 'primary.main',
+    mb: theme.spacing(2),
+  };
+
+  return (
+    <>
+      <Breadcrumbs items={breadcrumb}></Breadcrumbs>
+      <Typography variant="h1" sx={titleStyles}>
+        {title}
+      </Typography>
+      <Paper>
+        <DataTable
+          rows={tableData.rows}
+          columns={tableData.columns}
+          toolbar={tableData.toolbar}
+        />
+      </Paper>
+    </>
+  );
+}

--- a/src/components/04-pages/faculty/courses/course-details/course-details.tsx
+++ b/src/components/04-pages/faculty/courses/course-details/course-details.tsx
@@ -190,7 +190,7 @@ export default function CourseDetailsPage({
           ref={tabRef}
         >
           <div
-            title="Students"
+            aria-label="Students"
             className="tabContainer"
           >
             <Paper sx={contentContainerStyles}>
@@ -202,7 +202,7 @@ export default function CourseDetailsPage({
             </Paper>
           </div>
           <div
-            title="Experiences"
+            aria-label="Experiences"
             className="tab-container"
           >
             <Paper sx={contentContainerStyles}>

--- a/src/components/04-pages/generic/data-table-page.tsx
+++ b/src/components/04-pages/generic/data-table-page.tsx
@@ -121,7 +121,7 @@ export default function DataTablePage({
       {form && <ExposedForm {...form}></ExposedForm>}
       {tableData && membershipRequestedTableData ? (
         <Tabs id="staff-tabs" name="Staff Tabs">
-          <Box title="Staff members">
+          <Box aria-label="Staff members">
             <DataTable
               rows={tableData.rows}
               columns={tableData.columns}
@@ -130,7 +130,7 @@ export default function DataTablePage({
               hideCols={tableData.hideCols}
             />
           </Box>
-          <Box title="Memberships Requests">
+          <Box aria-label="Memberships Requests">
             <DataTable
               rows={membershipRequestedTableData.rows}
               columns={membershipRequestedTableData.columns}


### PR DESCRIPTION
## Purpose:
- Added a new data-table component called `ApproveExperienceTable`

### Ticket(s)
CSU-524 Partners can access an "Approve Experience(s)" page listing the experiences waiting to be approved

### Pull Request Deployment:
- `npm run dev`
- load `/?path=/story/pages-experiences-approve-experience--approve-experience`

### Functional Testing:
- [ ] Make sure that the table fit Brianna's requirements:
> The page should include a table of experiences associated with the organization's offering(s). Show only experiences in the "reviewing" state, with thee below values (columns) visible, sorted by experience ID (asc) so the oldest is seen first by default:
–Offering Name
–Offering Department (if applicable, otherwise hide column if the Org doesn't have any departments)
–Student Name
–University
–Opportunity Program
Operations in the far right column:
–Approve
–Deny

#### Notes
Aproveché el PR para hacer unos arreglos menores a unos tabs que no funcionaban porque hace unas semanas se cambió el prop de 'title' a 'aria-label' por conflictos con accesibilidad.
