### PR TITLE
CSU-533: Added new acordion behavior to open when an error appears

### DIFF
--- a/src/components/02-components/offering-form/offering-form.tsx
+++ b/src/components/02-components/offering-form/offering-form.tsx
@@ -395,7 +395,33 @@ export default function OfferingForm({
     setErrors(errors);
 
     if (Object.values(errors).some((error) => error)) {
-      (event.target as HTMLButtonElement).reportValidity(); // Display tooltips and prevent form submission
+      event.preventDefault();
+
+      const form = (event.target as HTMLButtonElement).form;
+      if (form) {
+        const firstInvalidInput = form.querySelector(':invalid') as HTMLElement;
+
+        if (firstInvalidInput) {
+          firstInvalidInput.scrollIntoView({ block: 'center', inline: 'nearest' });
+
+          const container = document.querySelector('main') || window;
+          const rect = firstInvalidInput.getBoundingClientRect();
+
+          const offsetTop = container === window
+            ? window.scrollY + rect.top - 157
+            : (container as HTMLElement).scrollTop + rect.top - 157;
+
+          (container as Window | HTMLElement).scrollTo({
+            top: offsetTop,
+            behavior: 'smooth',
+          });
+
+          setTimeout(() => {
+            firstInvalidInput.focus();
+            form.reportValidity();
+          }, 300);
+        }
+      }
     }
   };
 

--- a/src/components/02-components/opportunity-card/opportunity-card.tsx
+++ b/src/components/02-components/opportunity-card/opportunity-card.tsx
@@ -17,7 +17,7 @@ export type OpportunityCardProps = {
   id: string | number;
   title: string;
   url: string;
-  destinationUrl: string;
+  destinationUrl?: string;
   location?: string;
   type?: string;
   timeCommitment?: string;
@@ -215,7 +215,7 @@ export default function OpportunityCard({
             >
               View details
             </Button>
-            {!cardSelected && (
+            {!cardSelected && destinationUrl && (
               <Button
                 variant="contained"
                 component={Link}

--- a/src/components/02-components/opportunity-page/opportunity-page.tsx
+++ b/src/components/02-components/opportunity-page/opportunity-page.tsx
@@ -10,7 +10,7 @@ export type OpportunityPageProps = {
   }[];
   title: string;
   description: string;
-  selectURL: string;
+  selectURL?: string;
   address: string;
   type: string;
   timeCommitment: string;
@@ -136,14 +136,16 @@ export default function OpportunityPage({
               Opportunity Summary
             </Typography>
             <div dangerouslySetInnerHTML={{ __html: description }} />
-            <Button
-              variant="contained"
-              component={Link}
-              href={selectURL}
-              sx={{ flexShrink: 0, fontWeight: '700' }}
-            >
-              Select
-            </Button>
+            {selectURL && (
+              <Button
+                variant="contained"
+                component={Link}
+                href={selectURL}
+                sx={{ flexShrink: 0, fontWeight: '700' }}
+              >
+                Select
+              </Button>
+            )}
           </Box>
           <Box sx={style25}>
             <ul>

--- a/src/components/02-components/organization-form/organization-form.tsx
+++ b/src/components/02-components/organization-form/organization-form.tsx
@@ -218,6 +218,9 @@ export default function OrganizationForm({
     orgContactEmail: false,
   });
 
+  // Check if form has errors to expand accordion panels
+  const [accordionExpanded, setAccordionExpanded] = useState(false);
+
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     const orgNameValue = (document.getElementById('org-form-name') as HTMLInputElement)?.value;
     const orgSectorValue = (document.getElementById('org-form-industry') as HTMLInputElement)?.value;
@@ -275,6 +278,8 @@ export default function OrganizationForm({
           }, 300);
         }
       }
+      // (event.target as HTMLButtonElement).reportValidity(); // Display tooltips and prevent form submission
+      // setAccordionExpanded(true); // Expand the accordion when there are errors
     }
   };
 
@@ -287,6 +292,7 @@ export default function OrganizationForm({
         ref={tabRef}
       >
         <div aria-label="General Information">
+          {/* TODO: Based on CSU-533 S4 needs to discuss if they want to keep defaultExpanded or use expanded prop like line 386 */}
           <Accordion defaultExpanded={true} sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >
               General Information
@@ -404,7 +410,7 @@ export default function OrganizationForm({
               />
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={accordionStyles}>
+          <Accordion sx={accordionStyles} expanded={accordionExpanded} onChange={() => setAccordionExpanded(!accordionExpanded)}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Focus Population and Areas</AccordionSummary>
             <AccordionDetails>
               <AutocompleteField
@@ -445,7 +451,7 @@ export default function OrganizationForm({
               />
             </AccordionDetails>
           </Accordion>
-          <Accordion defaultExpanded={false} sx={accordionStyles}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Default Offering Settings</AccordionSummary>
             <AccordionDetails>
               <Typography sx={formFieldStyles}>
@@ -468,7 +474,7 @@ export default function OrganizationForm({
         </div>
 
         <div aria-label="Contacts">
-          <Accordion defaultExpanded={true} sx={accordionStyles}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >General Contact Information</AccordionSummary>
             <AccordionDetails>
               <FormControl fullWidth>
@@ -574,7 +580,7 @@ export default function OrganizationForm({
               />
             </AccordionDetails>
           </Accordion>
-          <Accordion defaultExpanded={false} sx={accordionStyles}>
+          <Accordion sx={accordionStyles} expanded={accordionExpanded} onChange={() => setAccordionExpanded(!accordionExpanded)}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Primary Contact</AccordionSummary>
             <AccordionDetails>
               <TextField

--- a/src/components/02-components/organization-form/organization-form.tsx
+++ b/src/components/02-components/organization-form/organization-form.tsx
@@ -258,6 +258,21 @@ export default function OrganizationForm({
         const firstInvalidInput = form.querySelector(':invalid') as HTMLElement;
 
         if (firstInvalidInput) {
+          // Encuentra el acordeón contenedor del campo inválido
+          const accordion = firstInvalidInput.closest('.MuiAccordion-root') as HTMLElement;
+          if (accordion) {
+            // Verifica si el acordeón ya está expandido
+            const isExpanded = accordion.classList.contains('Mui-expanded');
+            if (!isExpanded) {
+              // Solo abre el acordeón si no está expandido
+              const accordionSummary = accordion.querySelector('.MuiAccordionSummary-root') as HTMLElement;
+              if (accordionSummary) {
+                accordionSummary.click();
+              }
+            }
+          }
+
+          // Desplazarse al campo inválido
           firstInvalidInput.scrollIntoView({ block: 'center', inline: 'nearest' });
 
           const container = document.querySelector('main') || window;
@@ -278,8 +293,6 @@ export default function OrganizationForm({
           }, 300);
         }
       }
-      // (event.target as HTMLButtonElement).reportValidity(); // Display tooltips and prevent form submission
-      // setAccordionExpanded(true); // Expand the accordion when there are errors
     }
   };
 
@@ -410,7 +423,7 @@ export default function OrganizationForm({
               />
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={accordionStyles} expanded={accordionExpanded} onChange={() => setAccordionExpanded(!accordionExpanded)}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Focus Population and Areas</AccordionSummary>
             <AccordionDetails>
               <AutocompleteField
@@ -580,7 +593,7 @@ export default function OrganizationForm({
               />
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={accordionStyles} expanded={accordionExpanded} onChange={() => setAccordionExpanded(!accordionExpanded)}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Primary Contact</AccordionSummary>
             <AccordionDetails>
               <TextField
@@ -656,7 +669,7 @@ export default function OrganizationForm({
             </AccordionDetails>
           </Accordion>
 
-          <Accordion defaultExpanded={false} sx={accordionStyles}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Legal Contact</AccordionSummary>
             <AccordionDetails>
               <FormControlLabel
@@ -721,7 +734,7 @@ export default function OrganizationForm({
             </AccordionDetails>
           </Accordion>
 
-          <Accordion defaultExpanded={false} sx={accordionStyles}>
+          <Accordion sx={accordionStyles}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark' }} />} >Organization's Student Contact</AccordionSummary>
             <AccordionDetails>
               <TextField

--- a/src/components/02-components/organization-form/organization-form.tsx
+++ b/src/components/02-components/organization-form/organization-form.tsx
@@ -218,9 +218,6 @@ export default function OrganizationForm({
     orgContactEmail: false,
   });
 
-  // Check if form has errors to expand accordion panels
-  const [accordionExpanded, setAccordionExpanded] = useState(false);
-
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     const orgNameValue = (document.getElementById('org-form-name') as HTMLInputElement)?.value;
     const orgSectorValue = (document.getElementById('org-form-industry') as HTMLInputElement)?.value;
@@ -258,13 +255,13 @@ export default function OrganizationForm({
         const firstInvalidInput = form.querySelector(':invalid') as HTMLElement;
 
         if (firstInvalidInput) {
-          // Encuentra el acordeón contenedor del campo inválido
+          // Finds the accordion container of the invalid field
           const accordion = firstInvalidInput.closest('.MuiAccordion-root') as HTMLElement;
           if (accordion) {
             // Verifica si el acordeón ya está expandido
             const isExpanded = accordion.classList.contains('Mui-expanded');
             if (!isExpanded) {
-              // Solo abre el acordeón si no está expandido
+              // Checks if the accordion is already expanded
               const accordionSummary = accordion.querySelector('.MuiAccordionSummary-root') as HTMLElement;
               if (accordionSummary) {
                 accordionSummary.click();
@@ -272,7 +269,7 @@ export default function OrganizationForm({
             }
           }
 
-          // Desplazarse al campo inválido
+          // Move to invalid field
           firstInvalidInput.scrollIntoView({ block: 'center', inline: 'nearest' });
 
           const container = document.querySelector('main') || window;

--- a/src/components/02-components/organization-form/organization-form.tsx
+++ b/src/components/02-components/organization-form/organization-form.tsx
@@ -248,7 +248,33 @@ export default function OrganizationForm({
     setErrors(errors);
 
     if (Object.values(errors).some((error) => error)) {
-      (event.target as HTMLButtonElement).reportValidity(); // Display tooltips and prevent form submission
+      event.preventDefault();
+
+      const form = (event.target as HTMLButtonElement).form;
+      if (form) {
+        const firstInvalidInput = form.querySelector(':invalid') as HTMLElement;
+
+        if (firstInvalidInput) {
+          firstInvalidInput.scrollIntoView({ block: 'center', inline: 'nearest' });
+
+          const container = document.querySelector('main') || window;
+          const rect = firstInvalidInput.getBoundingClientRect();
+
+          const offsetTop = container === window
+            ? window.scrollY + rect.top - 157
+            : (container as HTMLElement).scrollTop + rect.top - 157;
+
+          (container as Window | HTMLElement).scrollTo({
+            top: offsetTop,
+            behavior: 'smooth',
+          });
+
+          setTimeout(() => {
+            firstInvalidInput.focus();
+            form.reportValidity();
+          }, 300);
+        }
+      }
     }
   };
 

--- a/src/components/02-components/student-experience-form-step2/student-experience-form-step2.tsx
+++ b/src/components/02-components/student-experience-form-step2/student-experience-form-step2.tsx
@@ -38,6 +38,7 @@ export default function StudentExperienceFormStep2({
   errorMsg,
 }: StudentExperienceFormStep2Props) {
   const theme = useTheme();
+  const [currentOpportunityCourseId, setCurrentOpportunityCourseId] = useState(opportunityCourseId || '');
 
   // Styles.
   const contentContainerStyles = {
@@ -104,6 +105,11 @@ export default function StudentExperienceFormStep2({
             options={courseValues}
             selected={defaultSelect}
             sx={formFieldStyles}
+            onChange={(_, value) => {
+              if (value && !Array.isArray(value) && 'id' in value) {
+                setCurrentOpportunityCourseId(value.id);
+              }
+            }}
           />
         )}
         {errorMsg && (
@@ -116,7 +122,7 @@ export default function StudentExperienceFormStep2({
         )}
       </Paper>
       <input type="hidden" name="opportunityId" value={ opportunityId } />
-      <input type="hidden" name="opportunityCourse" value={ opportunityCourseId } />
+      <input type="hidden" name="opportunityCourse" value={currentOpportunityCourseId} />
       <input type="hidden" name="programId" value={ programId } />
       <Button type="button" href="/create-experience" variant="outlined" sx={{ mr: 1, float: 'left' }}>Cancel</Button>
       <Button type="submit" variant="contained" sx={{ mr: 1, float: 'right' }}>Continue</Button>


### PR DESCRIPTION
## Purpose:
- Added a way to open the accordion from this form if they have empty mandatory fields nested.

### Ticket(s)
CSU-533 If field validation errors are triggered inside of an accordion, open the accordion

### Pull Request Deployment:
- `nvm use`
- `npm run dev`

### Functional Testing:
- [ ] load `/?path=/story/components-organizationform--add-organization` and `/?path=/story/components-organizationform--edit-organization` 
- [ ] test the form with empty required fields accordions must open automatically

### Notes:
N/A