### PR TITLE
CSU-535: Update components of opportunities to remove select button

### DIFF
--- a/src/components/02-components/opportunity-card/opportunity-card.tsx
+++ b/src/components/02-components/opportunity-card/opportunity-card.tsx
@@ -17,7 +17,7 @@ export type OpportunityCardProps = {
   id: string | number;
   title: string;
   url: string;
-  destinationUrl: string;
+  destinationUrl?: string;
   location?: string;
   type?: string;
   timeCommitment?: string;
@@ -215,7 +215,7 @@ export default function OpportunityCard({
             >
               View details
             </Button>
-            {!cardSelected && (
+            {!cardSelected && destinationUrl && (
               <Button
                 variant="contained"
                 component={Link}

--- a/src/components/02-components/opportunity-page/opportunity-page.tsx
+++ b/src/components/02-components/opportunity-page/opportunity-page.tsx
@@ -10,7 +10,7 @@ export type OpportunityPageProps = {
   }[];
   title: string;
   description: string;
-  selectURL: string;
+  selectURL?: string;
   address: string;
   type: string;
   timeCommitment: string;
@@ -136,14 +136,16 @@ export default function OpportunityPage({
               Opportunity Summary
             </Typography>
             <div dangerouslySetInnerHTML={{ __html: description }} />
-            <Button
-              variant="contained"
-              component={Link}
-              href={selectURL}
-              sx={{ flexShrink: 0, fontWeight: '700' }}
-            >
-              Select
-            </Button>
+            {selectURL && (
+              <Button
+                variant="contained"
+                component={Link}
+                href={selectURL}
+                sx={{ flexShrink: 0, fontWeight: '700' }}
+              >
+                Select
+              </Button>
+            )}
           </Box>
           <Box sx={style25}>
             <ul>


### PR DESCRIPTION
## Purpose:
Update components of opportunities to remove select button

### Ticket(s)
CSU-535: BUG: Experiences are not being showed in the landing page and experiences pages in the student FE

### Pull Request Deployment:
- pull
- npm run dev

### Functional Testing:
- [ ] go to opportunity-card-stories and remove text from destinationURL;
- [ ] go to opportunity-page-stories and remove text from destinationURL;
- [ ] Make sure bot components dont show share box

### Notes:
_Additional notes_
