### PR TITLE
CSU-566: Add state to card experience functionality

### DIFF
--- a/src/components/02-components/card-experience-hours/card-experience-hours.tsx
+++ b/src/components/02-components/card-experience-hours/card-experience-hours.tsx
@@ -4,12 +4,14 @@ export type CardExperienceHoursProps = {
   hours: number;
   cta?: string;
   position: string;
+  state?: string;
 };
 
 export default function CardExperienceHours({
   hours,
   cta,
   position,
+  state,
 }: CardExperienceHoursProps) {
   const theme = useTheme();
 
@@ -89,7 +91,7 @@ export default function CardExperienceHours({
         {renderedHours}
         {renderedHoursText}
       </Box>
-      {cta ? (
+      {cta && state === "Active" ? (
         <Button sx={buttonStyles} href={cta}>
           Log Time
         </Button>

--- a/src/components/02-components/card-experience/card-experience.tsx
+++ b/src/components/02-components/card-experience/card-experience.tsx
@@ -289,6 +289,7 @@ export default function CardExperience({
             hours={hours}
             cta={hoursCtaUrl}
             position={cardNumberVariation}
+            state={states[state].label}
           />
 
           {cardCount > 1 && (


### PR DESCRIPTION
## Purpose:
- Add state to card experience functionality

### Ticket(s)
CSU-566: Only "active" experiences should show the "log time" CTA on experience pages

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...

### Notes:
_Additional notes_
